### PR TITLE
Microsoft declared to require the "--scope <scope path>" parameter in…

### DIFF
--- a/bash/02.grantContributorRole.sh
+++ b/bash/02.grantContributorRole.sh
@@ -7,7 +7,7 @@ echo "Granting Contributor role ..."
 az role assignment create \
 --assignee "$SAG_SERVICE_PRINCIPAL_ID" \
 --role "Contributor" \
---resource-group "$SAG_AZ_RG_NAME" \
---subscription "$SAG_AZ_SUBSCRIPTION_ID"
+--subscription "$SAG_AZ_SUBSCRIPTION_ID" \
+--scope "/subscriptions/$SAG_AZ_SUBSCRIPTION_ID/resourceGroups/$SAG_AZ_RG_NAME"
 
 echo "Granted Contributor role, result $?"


### PR DESCRIPTION
… fall 2023. Removed "--resource-group" (for redundancy reason) and added "--scope" with corresponding value. Value for "--scope" has been built basing on a previously created RG and assigned role.