### PR TITLE
set orchestration mode to uniform

### DIFF
--- a/bash/05.createVmss.sh
+++ b/bash/05.createVmss.sh
@@ -13,6 +13,7 @@ az vmss create \
 --storage-sku StandardSSD_LRS \
 --authentication-type SSH \
 --instance-count 0 \
+--orchestration-mode uniform \
 --disable-overprovision \
 --upgrade-policy-mode manual \
 --single-placement-group false \


### PR DESCRIPTION
Set default orchestration mode to uniform to resolve the below error: 
"usage error: --disable-overprovision is not supported for Flex mode"